### PR TITLE
Adds terminal arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Convert .FLAC files in a folder to MP3 with metadata using ffmpeg and Python 
 on MacOS.  
 
-* Asks for a folder via drag and drop
+* Gets folder containing FLAC files
+	* Checks to see if a folder location was passed via command line
+	* Asks for a folder via user input/drag-and-drop if not passed
 * Recursively searches that folder for FLAC files and generates a list
 * Uses a terminal command to call ffmpeg to convert the FLAC file to mp3
 * Saves new mp3 file in same directory as located FLAC file

--- a/flac2mp3/convert.py
+++ b/flac2mp3/convert.py
@@ -2,9 +2,13 @@
 """
 Gets a source folder and searches it for FLAC files. Converts FLAC files
 to mp3 files in the same folder. 
+
+You can pass the directory to the script at the command line or the script 
+will request it at runtime. 
 """
 import subprocess
 import time
+import sys
 from os import path
 from pathlib import Path
 
@@ -63,10 +67,16 @@ def convert_files(fl: list) -> None:
 
 def main() -> None:
     """
-    Call all the functions to search for FLAC files and convert them to mp3.
+    Gets the folder containing the FLAC files via terminal argument or via 
+    user input, then calls all the functions to search for FLAC files and 
+    converts them to mp3.
     """
-    # Get source folder
-    source_folder = get_folder()
+    # Check for command line arguments
+    if sys.argv[1]:
+        source_folder = sys.argv[1]
+    else:
+        # Get source folder via user input/drag-and-drop
+        source_folder = get_folder()
     # Search source folder for FLAC files and generate a list.
     flac_list = get_source_files(source_folder)
     # If the list of files isn't empty, show number found and convert

--- a/flac2mp3/convert.py
+++ b/flac2mp3/convert.py
@@ -72,9 +72,9 @@ def main() -> None:
     converts them to mp3.
     """
     # Check for command line arguments
-    if sys.argv[1]:
+    try:
         source_folder = sys.argv[1]
-    else:
+    except IndexError:
         # Get source folder via user input/drag-and-drop
         source_folder = get_folder()
     # Search source folder for FLAC files and generate a list.


### PR DESCRIPTION
Adds the option to pass a source directory location via terminal when running initial command. 

Ex: 
```bash
$ python3 flac2mp3 /root
```

Still asks for directory via user input if not passed at runtime. 

Closes #2 